### PR TITLE
fix: ajuste na serializacao do do data no log interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.1] - Feat Download
+
+- ajuste na serializacao do do data no log interceptor
 
 ## [1.1.0] - Feat Download
 

--- a/lib/src/interceptors/pop_network_log_interceptor.dart
+++ b/lib/src/interceptors/pop_network_log_interceptor.dart
@@ -127,10 +127,14 @@ extension _ResponseExtension on Response {
     if (requestOptions.responseType == ResponseType.bytes) {
       return _formatTypeBytes;
     }
-    final jsonFormatado = JsonEncoder.withIndent('  ').convert(data);
-    return jsonFormatado.replaceFirst(
-      RegExp(r'(?<="video": \[)[^[]+(?=])'),
-      '"A lot of bytes..."',
-    );
+    try {
+      final jsonFormatado = JsonEncoder.withIndent('  ').convert(data);
+      return jsonFormatado.replaceFirst(
+        RegExp(r'(?<="video": \[)[^[]+(?=])'),
+        '"A lot of bytes..."',
+      );
+    } catch (e) {
+      return 'Error formatting data: ${e.toString()}';
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pop_network
 description: The plug-in built to simplify HTTP requests and help the developer to make good use of the Rest API's.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/PopcodeMobile/popnetwork
 repository: https://github.com/PopcodeMobile/popnetwork
 


### PR DESCRIPTION
<p align="center">
   <img src="https://user-images.githubusercontent.com/66264766/157141908-c8a760f7-6e13-4046-90f6-9243f698062b.png" alt="dt money" width="200"/>
</p>

## :computer:  Ajuste na serializacao do do data no log interceptor



## :computer: Descrição

Ao usar a função de `download` e passar pelo interpector de log era serializado o `data` do Response e dava erro 


---

**Checklist**

- [ ] Adicionei uma nova feture
- [x] Ajustei um Bug
- [ ] Adicionei novos testes
- [ ] Todos os testes estão rodando
- [ ] Added a link to the repo in the PR

---
