### PR TITLE
Fix: reordenar interceptor de logger para ser executado por ultimo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.1.2] - Fix order from the logger interceptor
+
+- Add logic to order the list of interceptors to put the logger interceptor as the last item in the list.
+
 ## [1.1.1] - Feat Download
 
 - adjustment in data serialization in interceptor log

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the `pop_network` package to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  pop_network: ^1.1.1
+  pop_network: ^1.1.2
 ```
 
 Then run pub get to install the package.

--- a/lib/src/api_manager.dart
+++ b/lib/src/api_manager.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:pop_network/src/i_api_manager.dart';
+import 'package:pop_network/src/interceptors/pop_network_log_interceptor.dart';
 import 'package:pop_network/src/mock/mock_reply_params.dart';
 
 class ApiManager extends IApiManager {
@@ -251,5 +252,27 @@ class ApiManager extends IApiManager {
       deleteOnError: deleteOnError,
       lengthHeader: lengthHeader,
     );
+  }
+
+  @override
+  Interceptors get interceptors {
+    if (super
+        .interceptors
+        .any((interceptor) => interceptor is PopNetworkLogInterceptor)) {
+      if (super.interceptors.last is PopNetworkLogInterceptor) {
+        return super.interceptors;
+      }
+
+      final indexPopNetworkLogInterceptor = super.interceptors.indexWhere(
+            (interceptor) => interceptor is PopNetworkLogInterceptor,
+          );
+
+      final popNetworkLogInterceptor =
+          super.interceptors.removeAt(indexPopNetworkLogInterceptor);
+
+      super.interceptors.add(popNetworkLogInterceptor);
+    }
+
+    return super.interceptors;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pop_network
 description: The plug-in built to simplify HTTP requests and help the developer to make good use of the Rest API's.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/PopcodeMobile/popnetwork
 repository: https://github.com/PopcodeMobile/popnetwork
 


### PR DESCRIPTION
<p align="center">
   <img src="https://user-images.githubusercontent.com/66264766/157141908-c8a760f7-6e13-4046-90f6-9243f698062b.png" alt="dt money" width="200"/>
</p>

## :computer: Reordenado interceptor de logger para ser executado por último

## :computer: Descrição

Alteração de código para que o interceptor de logger ocorra após a finalização de todos os interceptors anteriores.

## 📷 : Screenshots


<div align="center">
   <img src="https://github.com/user-attachments/assets/ecf7a449-ab3c-4998-ab3e-01fa447a2b6f" width="700"/>
</div>

<div align="center">
   <img src="https://github.com/user-attachments/assets/afe09b07-1b87-49f3-ac22-eee3041cf2ce" width="700"/>
</div>

---

**Checklist**

- [ ] Adicionei uma nova feture
- [x] Ajustei um Bug
- [ ] Adicionei novos testes
- [ ] Todos os testes estão rodando
- [ ] Added a link to the repo in the PR

---
